### PR TITLE
WpContext // fix isLoginRequest() to use correct new WP 6.1 Core function

### DIFF
--- a/src/WpContext.php
+++ b/src/WpContext.php
@@ -157,7 +157,9 @@ class WpContext implements \JsonSerializable
          * phpcs:disable WordPress.Security.ValidatedSanitizedInput.MissingUnslash
          * phpcs:disable WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
          */
-        return false !== stripos(wp_login_url(), $_SERVER['SCRIPT_NAME']);
+        $scriptName = $_SERVER['SCRIPT_NAME'] ?? '';
+
+        return false !== stripos(wp_login_url(), $scriptName);
     }
 
     /**

--- a/src/WpContext.php
+++ b/src/WpContext.php
@@ -150,7 +150,11 @@ class WpContext implements \JsonSerializable
             return true;
         }
 
-        return static::isPageNow('wp-login.php', wp_login_url());
+        /**
+         * Fallback and 1:1 copy from is_login() in case, the function is
+         * not available for WP < 6.1.
+         */
+        return false !== stripos(wp_login_url(), $_SERVER['SCRIPT_NAME']);
     }
 
     /**

--- a/src/WpContext.php
+++ b/src/WpContext.php
@@ -153,6 +153,9 @@ class WpContext implements \JsonSerializable
         /**
          * Fallback and 1:1 copy from is_login() in case, the function is
          * not available for WP < 6.1.
+         * phpcs:disable WordPress.Security.ValidatedSanitizedInput.InputNotValidated
+         * phpcs:disable WordPress.Security.ValidatedSanitizedInput.MissingUnslash
+         * phpcs:disable WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
          */
         return false !== stripos(wp_login_url(), $_SERVER['SCRIPT_NAME']);
     }

--- a/src/WpContext.php
+++ b/src/WpContext.php
@@ -138,9 +138,12 @@ class WpContext implements \JsonSerializable
      */
     private static function isLoginRequest(): bool
     {
-        /** TODO: we'll just use is_login_screen() when 6.1 will be the min WP supported version */
-        if (function_exists('is_login_screen')) {
-            return is_login_screen() !== false;
+        /**
+         * New core function with WordPress 6.1
+         * @link https://make.wordpress.org/core/2022/09/11/new-is_login-function-for-determining-if-a-page-is-the-login-screen/
+         */
+        if (function_exists('is_login')) {
+            return is_login() !== false;
         }
 
         if (!empty($_REQUEST['interim-login'])) { // phpcs:ignore

--- a/tests/WpContextTest.php
+++ b/tests/WpContextTest.php
@@ -460,7 +460,7 @@ class WpContextTest extends TestCase
     private function mockIsLoginRequest(bool $is): void
     {
         $is and $this->currentPath = '/wp-login.php';
-        Monkey\Functions\when('wp_login_url')->justReturn('https://example.com/wp-login.php');
+        Monkey\Functions\when('is_login')->justReturn($is);
     }
 
     /**


### PR DESCRIPTION
Since WordPress 6.1 there is a new Core function is_login() which will determine if the current request is going to the WordPress login page. Originally we checked for "is_login_screen()" but WordPress decided to name that function differently.

See: https://make.wordpress.org/core/2022/09/11/new-is_login-function-for-determining-if-a-page-is-the-login-screen/
Core Trac: https://core.trac.wordpress.org/ticket/19898

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [x] Docs have been added/updated (for bug fixes/features)


-----

**Additional information**

Caused by: https://github.com/inpsyde/assets/issues/48