### PR TITLE
Psalm suppress for RedundantCondition & MixedArgument

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+/.idea/
 /vendor/
 phpunit.xml
 .phpunit.result.cache

--- a/src/WpContext.php
+++ b/src/WpContext.php
@@ -103,14 +103,14 @@ class WpContext implements \JsonSerializable
     }
 
     /**
+     * @psalm-suppress RedundantCondition
      * @return bool
      */
     private static function isRestRequest(): bool
     {
-        if (
-            (defined('REST_REQUEST') && REST_REQUEST)
-            || !empty($_GET['rest_route']) // phpcs:ignore
-        ) {
+        /** @psalm-suppress RedundantCondition */
+        $isRestRequest = defined('REST_REQUEST') && REST_REQUEST;
+        if ($isRestRequest || !empty($_GET['rest_route'])) { // phpcs:ignore
             return true;
         }
 
@@ -372,6 +372,7 @@ class WpContext implements \JsonSerializable
         ];
 
         foreach ($this->actionCallbacks as $action => $callback) {
+            /** @psalm-suppress MixedArgument */
             add_action($action, $callback, PHP_INT_MIN);
         }
     }
@@ -385,6 +386,7 @@ class WpContext implements \JsonSerializable
     private function removeActionHooks(): void
     {
         foreach ($this->actionCallbacks as $action => $callback) {
+            /** @psalm-suppress MixedArgument */
             remove_action($action, $callback, PHP_INT_MIN);
         }
         $this->actionCallbacks = [];

--- a/src/WpContext.php
+++ b/src/WpContext.php
@@ -103,7 +103,6 @@ class WpContext implements \JsonSerializable
     }
 
     /**
-     * @psalm-suppress RedundantCondition
      * @return bool
      */
     private static function isRestRequest(): bool


### PR DESCRIPTION
This PR adds /** @psalm-suppress */ comments to the code to allow the QA workflow to pass. These comments suppress false positives where Psalm incorrectly raises issues. 